### PR TITLE
Add link to the GitHub repository

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@
 <body>
 	<div class="top_links">
 		<p>Created by <a href="https://steamcommunity.com/id/napster653/">[ESPS] Napster653</a> with the help from [M] Kief and [ASC] LeventHAN</p>
-		<p><a href="https://www.paypal.me/PabloFerrer"> <img src="img/icons/paypal.png" width="25px"> Buy me a beer!</a></p>
+		<p><a href="https://www.paypal.me/PabloFerrer"><img src="img/icons/paypal.png" width="25px"> Buy me a beer!</a></p>
+		<p><a href="https://github.com/Napster653/SquadMaps" target="_BLANK">Contribute or leave a Star on GitHub</a>
 		<p><a href="https://joinsquad.com/2020/09/23/squad-v1-0-released/">Updated to V1!</a></p>
 	</div>
 	<header>


### PR DESCRIPTION
Added a link to the GitHub repository to the top_links section. That way, people can find the repository quicker and make contributions if neccessary.