### PR TITLE
Make maps section sticky

### DIFF
--- a/style/style.css
+++ b/style/style.css
@@ -45,6 +45,10 @@ section
 .headers_section
 {
 	text-align: center;
+	position: sticky;
+	z-index: 1;
+	top: 0;
+	box-shadow: 0 0 16px black;
 }
 section .headers
 {


### PR DESCRIPTION
I was having problems with going back to the page-top and clicking on other maps so I thought it might be better for everyone to make the maps section sticky thus it can be accessed any time without going to the top.

![QprEkwXuuh](https://user-images.githubusercontent.com/20087554/108552741-c3f9f800-7302-11eb-9d19-4293b2ff6f76.gif)

